### PR TITLE
c: vectorize table lookups

### DIFF
--- a/src/implementation/c/index.ts
+++ b/src/implementation/c/index.ts
@@ -36,6 +36,27 @@ export class CCompiler {
     out.push('#include <stdint.h>');
     out.push('#include <string.h>');
     out.push('');
+
+    // NOTE: Inspired by https://github.com/h2o/picohttpparser
+    // TODO(indutny): Windows support for SSE4.2.
+    // See: https://github.com/nodejs/llparse/pull/24#discussion_r299789676
+    // (There is no `__SSE4_2__` define for MSVC)
+    out.push('#ifdef __SSE4_2__');
+    out.push(' #ifdef _MSC_VER');
+    out.push('  #include <nmmintrin.h>');
+    out.push(' #else  /* !_MSC_VER */');
+    out.push('  #include <x86intrin.h>');
+    out.push(' #endif  /* _MSC_VER */');
+    out.push('#endif  /* __SSE4_2__ */');
+    out.push('');
+
+    out.push('#ifdef _MSC_VER');
+    out.push(' #define ALIGN(n) _declspec(align(n))');
+    out.push('#else  /* !_MSC_VER */');
+    out.push(' #define ALIGN(n) __attribute__((aligned(n)))');
+    out.push('#endif  /* _MSC_VER */');
+
+    out.push('');
     out.push(`#include "${this.options.header || info.prefix}.h"`);
     out.push(``);
     out.push(`typedef int (*${info.prefix}__span_cb)(`);

--- a/src/implementation/c/node/table-lookup.ts
+++ b/src/implementation/c/node/table-lookup.ts
@@ -7,6 +7,11 @@ import { Node } from './base';
 const MAX_CHAR = 0xff;
 const TABLE_GROUP = 16;
 
+// _mm_cmpestri takes 8 ranges
+const SSE_RANGES_LEN = 16;
+const MAX_SSE_CALLS = 2;
+const SSE_ALIGNMENT = 16;
+
 interface ITable {
   readonly name: string;
   readonly declaration: ReadonlyArray<string>;
@@ -24,8 +29,13 @@ export class TableLookup extends Node<frontend.node.TableLookup> {
     this.prologue(out);
 
     const transform = ctx.unwrapTransform(this.ref.transform!);
-    const current = transform.build(ctx, `*${ctx.posArg()}`);
 
+    // Try to vectorize nodes matching characters and looping to themselves
+    // NOTE: `switch` below triggers when there is not enough characters in the
+    // stream for vectorized processing.
+    this.buildSSE(out);
+
+    const current = transform.build(ctx, `*${ctx.posArg()}`);
     out.push(`switch (${table.name}[(uint8_t) ${current}]) {`);
 
     for (const [ index, edge ] of this.ref.edges.entries()) {
@@ -51,6 +61,102 @@ export class TableLookup extends Node<frontend.node.TableLookup> {
 
     out.push('  }');
     out.push('}');
+  }
+
+  private buildSSE(out: string[]): boolean {
+    const ctx = this.compilation;
+
+    // Transformation is not supported atm
+    if (this.ref.transform && this.ref.transform.ref.name !== 'id') {
+      return false;
+    }
+
+    if (this.ref.edges.length !== 1) {
+      return false;
+    }
+
+    const edge = this.ref.edges[0];
+    if (edge.node.ref !== this.ref) {
+      return false;
+    }
+
+    // NOTE: keys are sorted
+    let ranges: number[] = [];
+    let first: number | undefined;
+    let last: number | undefined;
+    for (const key of edge.keys) {
+      if (first === undefined) {
+        first = key;
+      }
+      if (last === undefined) {
+        last = key;
+      }
+
+      if (key - last > 1) {
+        ranges.push(first, last);
+        first = key;
+      }
+      last = key;
+    }
+    if (first !== undefined && last !== undefined) {
+      ranges.push(first, last);
+    }
+
+    if (ranges.length === 0) {
+      return false;
+    }
+
+    // Way too many calls would be required
+    if (ranges.length > MAX_SSE_CALLS * SSE_RANGES_LEN) {
+      return false;
+    }
+
+    out.push('#ifdef __SSE4_2__');
+    out.push(`if (${ctx.endPosArg()} - ${ctx.posArg()} >= 16) {`);
+    out.push('  __m128i ranges;');
+    out.push('  __m128i input;');
+    out.push('  int avail;');
+    out.push('  int match_len;');
+    out.push('');
+    out.push('  /* Load input */');
+    out.push(`  input = _mm_loadu_si128((__m128i const*) ${ctx.posArg()});`);
+    for (let off = 0; off < ranges.length; off += SSE_RANGES_LEN) {
+      const subRanges = ranges.slice(off, off + SSE_RANGES_LEN);
+
+      const blob = ctx.blob(Buffer.from(subRanges), SSE_ALIGNMENT);
+      out.push(`  ranges = _mm_loadu_si128((__m128i const*) ${blob});`);
+      out.push('');
+
+      out.push('  /* Find first character that does not match `ranges` */');
+      out.push(`  match_len = _mm_cmpestri(ranges, ${subRanges.length},`);
+      out.push('      input, 16,');
+      out.push('      _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES |');
+      out.push('        _SIDD_NEGATIVE_POLARITY);');
+      out.push('');
+      out.push('  if (match_len != 0) {');
+      out.push(`    ${ctx.posArg()} += match_len;`);
+
+      const tmp: string[] = [];
+      assert.strictEqual(edge.noAdvance, false);
+      this.tailTo(tmp, {
+        noAdvance: true,
+        node: edge.node,
+      });
+      ctx.indent(out, tmp, '    ');
+
+      out.push('  }');
+    }
+
+    {
+      const tmp: string[] = [];
+      this.tailTo(tmp, this.ref.otherwise!);
+      ctx.indent(out, tmp, '  ');
+    }
+    out.push('}');
+
+    out.push('#endif  /* __SSE4_2__ */');
+
+    return true;
   }
 
   // TODO(indutny): reduce copy-paste between `C` and `bitcode` implementations

--- a/test/compiler-test.ts
+++ b/test/compiler-test.ts
@@ -200,6 +200,19 @@ describe('llparse/Compiler', () => {
       const binary = build(p, start, 'escape-char');
       await binary.check('\\\'', 'off=1\noff=2\n');
     });
+
+    it('should hit SSE4.2 optimization for table-lookup', async () => {
+      const start = p.node('start');
+
+      start
+        .match(ALPHA, start)
+        .skipTo(printOff(p, start));
+
+      // TODO(indutny): validate compilation result?
+      const binary = build(p, start, 'match-bit-check-sse');
+      await binary.check('abcdabcdabcdabcdabcdabcdabcd.abcd.',
+        'off=29\noff=34\n');
+    });
   });
 
   describe('`.peek()`', () => {

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -9,6 +9,7 @@ export { ERROR_PAUSE } from 'llparse-test-fixture';
 const fixtures = new Fixture({
   buildDir: path.join(__dirname, '..', 'tmp'),
   extra: [
+    '-msse4.2',
     '-DLLPARSE__TEST_INIT=llparse__test_init',
     path.join(__dirname, 'extra.c'),
   ],


### PR DESCRIPTION
Use SSE4.2 vector instructions to speed up matching. When node has a lot
characters to match and loops to itself, the table lookups could be
replaced with a call to `_mm_cmpestri`, skipping all matching characters
in the input stream.

cc @nodejs/http maybe?

---

The benchmark results (from llhttp) are:

No SSE:
```
url loose (C)
32768.00 mb | 1389.49 mb/s | 28018961.78 ops/sec | 23.58 s
url strict (C)
32768.00 mb | 1319.83 mb/s | 26614195.26 ops/sec | 24.83 s
http loose: "seanmonstar/httparse" (C)
32768.00 mb | 1236.92 mb/s | 1844958.53 ops/sec | 26.49 s
http strict: "seanmonstar/httparse" (C)
32768.00 mb | 989.90 mb/s | 1476514.44 ops/sec | 33.10 s
http loose: "nodejs/http-parser" (C)
32768.00 mb | 1181.67 mb/s | 2382818.56 ops/sec | 27.73 s
http strict: "nodejs/http-parser" (C)
32768.00 mb | 956.21 mb/s | 1928191.66 ops/sec | 34.27 s
```

SSE
```
url loose (C)
32768.00 mb | 1396.29 mb/s | 28156047.11 ops/sec | 23.47 s
url strict (C)
32768.00 mb | 1324.29 mb/s | 26704105.59 ops/sec | 24.74 s
http loose: "seanmonstar/httparse" (C)
32768.00 mb | 2043.78 mb/s | 3048452.47 ops/sec | 16.03 s
http strict: "seanmonstar/httparse" (C)
32768.00 mb | 1924.88 mb/s | 2871105.55 ops/sec | 17.02 s
http loose: "nodejs/http-parser" (C)
32768.00 mb | 1636.96 mb/s | 3300913.67 ops/sec | 20.02 s
http strict: "nodejs/http-parser" (C)
32768.00 mb | 1507.33 mb/s | 3039511.00 ops/sec | 21.74 s
```