### PR TITLE
c: fix blobs visibility for SSE4.2

### DIFF
--- a/src/implementation/c/compilation.ts
+++ b/src/implementation/c/compilation.ts
@@ -77,6 +77,9 @@ export class Compilation {
         align = ` ALIGN(${blob.alignment})`;
       }
 
+      if (blob.alignment) {
+        out.push('#ifdef __SSE4_2__');
+      }
       out.push(`static const unsigned char${align} ${blob.name}[] = {`);
 
       for (let i = 0; i < buffer.length; i += BLOB_GROUP_SIZE) {
@@ -103,6 +106,9 @@ export class Compilation {
       }
 
       out.push(`};`);
+      if (blob.alignment) {
+        out.push('#endif  /* __SSE4_2__ */');
+      }
     }
     out.push('');
   }


### PR DESCRIPTION
Currently in [llhttp](https://github.com/nodejs/llhttp):
```bash
$ make build/libllhttp.a 
npx ts-node bin/generate.ts
clang  -Os -g3 -Wall -Wextra -Wno-unused-parameter -Ibuild/ -c build/c/llhttp.c -o build/c/llhttp.o
build/c/llhttp.c:27:38: warning: unused variable 'llparse_blob1' [-Wunused-const-variable]
static const unsigned char ALIGN(16) llparse_blob1[] = {
                                     ^
build/c/llhttp.c:46:38: warning: unused variable 'llparse_blob7' [-Wunused-const-variable]
static const unsigned char ALIGN(16) llparse_blob7[] = {
                                     ^
build/c/llhttp.c:52:38: warning: unused variable 'llparse_blob9' [-Wunused-const-variable]
static const unsigned char ALIGN(16) llparse_blob9[] = {
                                     ^
build/c/llhttp.c:56:38: warning: unused variable 'llparse_blob10' [-Wunused-const-variable]
static const unsigned char ALIGN(16) llparse_blob10[] = {
                                     ^
4 warnings generated.
clang  -Os -g3 -Wall -Wextra -Wno-unused-parameter -Ibuild/ -c src/native/api.c -o build/native/api.o
clang  -Os -g3 -Wall -Wextra -Wno-unused-parameter -Ibuild/ -c src/native/http.c -o build/native/http.o
ar rcs build/libllhttp.a build/c/llhttp.o build/native/api.o build/native/http.o
```