### PR TITLE
prevent out-of-bounds reads when using SSE 4.2.

### DIFF
--- a/src/implementation/c/compilation.ts
+++ b/src/implementation/c/compilation.ts
@@ -77,10 +77,16 @@ export class Compilation {
         align = ` ALIGN(${blob.alignment})`;
       }
 
+      let size = '';
       if (blob.alignment) {
         out.push('#ifdef __SSE4_2__');
+        if (buffer.length < blob.alignment) {
+          // SSE4.2 instructions may read up to 16 bytes at once, so we need
+          // to make sure our static strings are at least 16 bytes long
+          size = blob.alignment;
+        }
       }
-      out.push(`static const unsigned char${align} ${blob.name}[] = {`);
+      out.push(`static const unsigned char${align} ${blob.name}[${size}] = {`);
 
       for (let i = 0; i < buffer.length; i += BLOB_GROUP_SIZE) {
         const limit = Math.min(buffer.length, i + BLOB_GROUP_SIZE);


### PR DESCRIPTION
in the SSE4.2 case, ensure the generated static strings are at least
${blob.alignment} characters long. the SSE4.2 _mm* instructions require
data not only to be 16-byte-aligned but also may read full 16 bytes
from the start address.
so far, there is no guarantee that the static strings used for
comparisons are actually in a memory area from which 16 bytes can safely
be read. this is up to the compiler.

motivation for the bugfix: when running an application that is using
llhttp, we are seeing address sanitizer out-of-bounds reads when loading
the static comparison strings into the _mm registers.

this PR is an attempt to fix this, by ensuring that the generated
compare strings are at least 16 bytes long in memory, so that this
memory can safely be read into an _mm register.

caveat: I have just patched the generator code to the best of my
knowledge, but didn't run it yet. but the current code without the
padding definitely has undefined behavior.