### PR TITLE
header-builder: add cptr type for constant pointers

### DIFF
--- a/src/compiler/header-builder.ts
+++ b/src/compiler/header-builder.ts
@@ -55,6 +55,8 @@ export class HeaderBuilder {
         ty = 'uint64_t';
       } else if (prop.ty === 'ptr') {
         ty = 'void*';
+      } else if (prop.ty === 'cptr') {
+        ty = 'const void*';
       } else {
         throw new Error(
           `Unknown state property type: "${prop.ty}"`);


### PR DESCRIPTION
For pointers to shared structures that the parser that will not modify, add
cptr type.  An example is the settings_t used in llhttp.