### PR TITLE
fix: return 0 on int function

### DIFF
--- a/test/fixtures/extra.c
+++ b/test/fixtures/extra.c
@@ -81,4 +81,5 @@ int llparse__pause_once(llparse_t* s, const char* p, const char* endp) {
 
 int llparse__test_init() {
   llparse__pause_once_counter = 0;
+  return 0;
 }


### PR DESCRIPTION
I get error in clang because this int function is not returning a 0 

-.-