### PR TITLE
chore: remove abort

### DIFF
--- a/src/implementation/c/compilation.ts
+++ b/src/implementation/c/compilation.ts
@@ -173,8 +173,6 @@ export class Compilation {
       out.push(`case ${name}:`);
       out.push(`${LABEL_PREFIX}${name}: {`);
       lines.forEach((line) => out.push(`  ${line}`));
-      out.push('  /* UNREACHABLE */;');
-      out.push('  abort();');
       out.push('}');
     });
   }
@@ -186,8 +184,6 @@ export class Compilation {
       }
       out.push(`${LABEL_PREFIX}${name}: {`);
       lines.forEach((line) => out.push(`  ${line}`));
-      out.push('  /* UNREACHABLE */;');
-      out.push('  abort();');
       out.push('}');
     });
   }

--- a/src/implementation/c/index.ts
+++ b/src/implementation/c/index.ts
@@ -92,9 +92,6 @@ export class CCompiler {
     compilation.buildResumptionStates(tmp);
     compilation.indent(out, tmp, '    ');
 
-    out.push('    default:');
-    out.push('      /* UNREACHABLE */');
-    out.push('      abort();');
     out.push('  }');
 
     tmp = [];


### PR DESCRIPTION
I dont know what the point is to have this unreachable code in the result. It increases the size of the generated wasm files. 