### PR TITLE
feat: add NEON support on arm64

### DIFF
--- a/src/implementation/c/index.ts
+++ b/src/implementation/c/index.ts
@@ -49,6 +49,11 @@ export class CCompiler {
     out.push('#endif  /* __SSE4_2__ */');
     out.push('');
 
+    out.push('#ifdef __ARM_NEON__');
+    out.push(' #include <arm_neon.h>');
+    out.push('#endif  /* __ARM_NEON__ */');
+    out.push('');
+
     out.push('#ifdef __wasm__');
     out.push(' #include <wasm_simd128.h>');
     out.push('#endif  /* __wasm__ */');

--- a/src/implementation/c/node/table-lookup.ts
+++ b/src/implementation/c/node/table-lookup.ts
@@ -11,6 +11,7 @@ const SSE_RANGES_LEN = 16;
 // _mm_cmpestri takes 128bit input
 const SSE_RANGES_PAD = 16;
 const MAX_SSE_CALLS = 2;
+const MAX_NEON_RANGES = 6;
 const MAX_WASM_RANGES = 6;
 const SSE_ALIGNMENT = 16;
 
@@ -37,6 +38,7 @@ export class TableLookup extends Node<frontend.node.TableLookup> {
     // stream for vectorized processing.
     if (this.canVectorize()) {
       this.buildSSE(out);
+      this.buildNeon(out);
       this.buildWASM(out);
     }
 
@@ -179,6 +181,91 @@ export class TableLookup extends Node<frontend.node.TableLookup> {
     out.push('}');
 
     out.push('#endif  /* __SSE4_2__ */');
+
+    return true;
+  }
+
+  private buildNeon(out: string[]): boolean {
+    const ctx = this.compilation;
+
+    const edge = this.ref.edges[0];
+    assert(edge !== undefined);
+
+    const ranges = this.buildRanges(edge);
+
+    if (ranges.length === 0) {
+      return false;
+    }
+
+    // Way too many calls would be required
+    if (ranges.length > MAX_NEON_RANGES) {
+      return false;
+    }
+
+    out.push('#ifdef __ARM_NEON__');
+    out.push(`while (${ctx.endPosArg()} - ${ctx.posArg()} >= 16) {`);
+    out.push('  uint8x16_t input;');
+    out.push('  uint8x16_t single;');
+    out.push('  uint8x16_t mask;');
+    out.push('  uint8x8_t narrow;');
+    out.push('  uint64_t match_mask;');
+    out.push('  int match_len;');
+    out.push('');
+    out.push('  /* Load input */');
+    out.push(`  input = vld1q_u8(${ctx.posArg()});`);
+
+    out.push('  /* Find first character that does not match `ranges` */');
+    function v128(value: number): string {
+      return `vdupq_n_u8(${ctx.toChar(value)})`;
+    }
+
+    for (let off = 0; off < ranges.length; off += 2) {
+      const start = ranges[off];
+      const end = ranges[off + 1];
+      assert(start !== undefined);
+      assert(end !== undefined);
+
+      // Same character, equality is sufficient (and faster)
+      if (start === end) {
+        out.push(`  single = vceqq_u8(input, ${v128(start)});`);
+      } else {
+        out.push(`  single = vandq_u16(`);
+        out.push(`    vcgeq_u8(input, ${v128(start)}),`);
+        out.push(`    vcleq_u8(input, ${v128(end)})`);
+        out.push('  );');
+      }
+
+      if (off === 0) {
+        out.push('  mask = single;');
+      } else {
+        out.push('  mask = vorrq_u16(mask, single);');
+      }
+    }
+
+    // https://community.arm.com/arm-community-blogs/b/servers-and-cloud-computing-blog/posts/porting-x86-vector-bitmask-optimizations-to-arm-neon
+    out.push('  narrow = vshrn_n_u16(mask, 4);');
+    out.push('  match_mask = ~vget_lane_u64(vreinterpret_u64_u8(narrow), 0);');
+    out.push('  match_len = __builtin_ctzll(match_mask) >> 2;');
+    out.push('  if (match_len != 16) {');
+    out.push(`    ${ctx.posArg()} += match_len;`);
+    {
+      const tmp: string[] = [];
+      this.tailTo(tmp, this.ref.otherwise!);
+      ctx.indent(out, tmp, '    ');
+    }
+    out.push('  }');
+    out.push(`  ${ctx.posArg()} += 16;`);
+    out.push('}');
+
+    out.push(`if (${ctx.posArg()} == ${ctx.endPosArg()}) {`);
+    {
+      const tmp: string[] = [];
+      this.pause(tmp);
+      this.compilation.indent(out, tmp, '  ');
+    }
+    out.push('}');
+
+    out.push('#endif  /* __ARM_NEON__ */');
 
     return true;
   }

--- a/test/fixtures/extra.c
+++ b/test/fixtures/extra.c
@@ -79,7 +79,6 @@ int llparse__pause_once(llparse_t* s, const char* p, const char* endp) {
 }
 
 
-int llparse__test_init() {
+void llparse__test_init(llparse_t*) {
   llparse__pause_once_counter = 0;
-  return 0;
 }


### PR DESCRIPTION
llhttp benchmarks on M2 mac. Before:

    url (C)
    8192.00 mb | 2190.59 mb/s | 44173087.93 ops/sec | 3.74 s
    http: "seanmonstar/httparse" (C)
    8192.00 mb | 1756.10 mb/s | 2619357.05 ops/sec | 4.66 s
    http: "nodejs/http-parser" (C)
    8192.00 mb | 1467.88 mb/s | 2959960.95 ops/sec | 5.58 s

After this commit:

    url (C)
    8192.00 mb | 2211.35 mb/s | 44591682.98 ops/sec | 3.70 s
    http: "seanmonstar/httparse" (C)
    8192.00 mb | 3183.58 mb/s | 4748540.45 ops/sec | 2.57 s
    http: "nodejs/http-parser" (C)
    8192.00 mb | 2123.17 mb/s | 4281349.70 ops/sec | 3.86 s

cc @mcollina @nodejs/llhttp 