### PR TITLE
chore: better UNREACHABLE macro

### DIFF
--- a/src/implementation/c/compilation.ts
+++ b/src/implementation/c/compilation.ts
@@ -166,8 +166,7 @@ export class Compilation {
       out.push(`case ${name}:`);
       out.push(`${LABEL_PREFIX}${name}: {`);
       lines.forEach((line) => out.push(`  ${line}`));
-      out.push('  /* UNREACHABLE */;');
-      out.push('  abort();');
+      out.push('  UNREACHABLE;');
       out.push('}');
     });
   }
@@ -179,8 +178,7 @@ export class Compilation {
       }
       out.push(`${LABEL_PREFIX}${name}: {`);
       lines.forEach((line) => out.push(`  ${line}`));
-      out.push('  /* UNREACHABLE */;');
-      out.push('  abort();');
+      out.push('  UNREACHABLE;');
       out.push('}');
     });
   }

--- a/src/implementation/c/index.ts
+++ b/src/implementation/c/index.ts
@@ -56,8 +56,10 @@ export class CCompiler {
 
     out.push('#ifdef _MSC_VER');
     out.push(' #define ALIGN(n) _declspec(align(n))');
+    out.push(' #define UNREACHABLE __assume(0)');
     out.push('#else  /* !_MSC_VER */');
     out.push(' #define ALIGN(n) __attribute__((aligned(n)))');
+    out.push(' #define UNREACHABLE __builtin_unreachable()');
     out.push('#endif  /* _MSC_VER */');
 
     out.push('');
@@ -98,8 +100,7 @@ export class CCompiler {
     compilation.indent(out, tmp, '    ');
 
     out.push('    default:');
-    out.push('      /* UNREACHABLE */');
-    out.push('      abort();');
+    out.push('      UNREACHABLE;');
     out.push('  }');
 
     tmp = [];


### PR DESCRIPTION
Use builtins for declaring the code as unreacahable:

- On Windows: `__assume(0)`
- On Unixes: `__builtin_unreachable()`

Fix #70 

cc @nodejs/llhttp 