### PR TITLE
add Unpack for unpacking integers.

### DIFF
--- a/src/implementation/c/code/index.ts
+++ b/src/implementation/c/code/index.ts
@@ -8,6 +8,7 @@ import { MulAdd } from './mul-add';
 import { Or } from './or';
 import { Store } from './store';
 import { Test } from './test';
+import { Unpack } from './unpack';
 import { Update } from './update';
 
 export * from './base';

--- a/src/implementation/c/code/unpack.ts
+++ b/src/implementation/c/code/unpack.ts
@@ -1,0 +1,43 @@
+import * as frontend from 'llparse-frontend';
+import * as assert from 'assert';
+import { UNSIGNED_LIMITS, UNSIGNED_TYPES } from '../constants';
+import { Compilation } from '../compilation';
+import { Field } from './field';
+
+export class Unpack extends Field<frontend.code.Unpack>{
+    // big endian will be rshift and little will be lshift
+    protected doBuild(ctx: Compilation, out: string[]): void {
+        const ty = ctx.getFieldType(this.ref.field);
+        assert(UNSIGNED_TYPES.has(ty), `Unexpected Unpack type "${ty}"`);
+        const targetTy = UNSIGNED_TYPES.get(ty)!;
+        const limit = UNSIGNED_LIMITS.get(ty)!;
+        const match = ctx.matchVar();
+        
+        /* NOTE: (Vizonex) Feel free to correct me if I'm wrong here about this C code. */
+        if (!this.ref.bigEndian){    
+            /* lshift */
+            out.push(`if (${this.field(ctx)} > 0){`);
+            out.push(`  ${targetTy} __lshift_val = ${this.field(ctx)} << 8;`);
+            out.push(`  if (__lshift_val > ${limit[1]} || __lshift_val < ${this.field(ctx)}){`);
+            out.push("    /* overflow */");
+            out.push("    return 1;");
+            out.push("  }");
+            out.push(`  ${this.field(ctx)} = __lshift_val | ${match}`);
+        } else {
+            out.push(`if (${this.field(ctx)} > 0){`);
+            out.push(`  ${targetTy} __rshift_val = ${this.field(ctx)} >> 8;`);
+            out.push(`  if (__rshift_val > ${limit[1]} || __rshift_val < ${this.field(ctx)}){`);
+            out.push("    /* overflow */");
+            out.push(`    return 1;`);
+            out.push(`  }`);
+            out.push(`  ${this.field(ctx)} =  ${match} | __rshift_val`);
+            out.push(`}`);
+            
+        }
+        /** if first value simply setting it in should be enough... */
+        out.push("} else {");
+        out.push(`  ${this.field(ctx)} = ${match};`);
+        out.push("}  ");
+        out.push("return 0;");
+    }
+}


### PR DESCRIPTION
Based off #32 I decided to try writing a better and simpler approach that is based off MulAdd but for implementing rshifting and lshifting based on weather or not big or little endians are to be used.  In my case I'm going to write a new socks5 protocol parser in C.

I have 2 more forks that will be merged since it's a new function and Node class but I've ensured that there is at least some tests available for it. I do have some skills I've learned from contributing to aiohttp and some of it's lower level C/Cython related code so I should be able to navigate things if the C code is wrong or you think it could be better. 

I'll upload those pull requests shortly...

Edit: here's a code snippet from one of the tests I added if anybody is confused about how this new code method works
```typescript
const start = b.node('start');
    b.property('i16', 'unpack_value');
    const unpack_error = b.error(0, 'failed to unpack value');
    const invoke = b.invoke(
      b.code.unpack('unpack_value', Endianess.Little),
      start, unpack_error
    );
```
